### PR TITLE
Fix for effect Z-score direction

### DIFF
--- a/eqtl-mapping-pipeline/src/main/java/eqtlmappingpipeline/interactionanalysis/InteractionAnalysisMultiThreaded.java
+++ b/eqtl-mapping-pipeline/src/main/java/eqtlmappingpipeline/interactionanalysis/InteractionAnalysisMultiThreaded.java
@@ -601,7 +601,7 @@ public class InteractionAnalysisMultiThreaded {
         nrInOutput = 0;
         System.out.println("Output will be written to: " + out + "InteractionResults.txt");
         TextFile outputFile = new TextFile(out + "InteractionResults.txt", TextFile.W);
-        String outputheader = "SNP\tProbe\tCovariate\tZ-SNP\tZ-Cov\tZ-Interaction\tZ-Main\tN";
+        String outputheader = "SNP\tProbe\tCovariate\tZ-SNP\tZ-Cov\tZ-Interaction\tZ-Main\tZ-Interaction-Flipped\tN\tRSquared";
         if (fullStats) {
             outputheader
                     += "\tsnpBeta"
@@ -609,8 +609,8 @@ public class InteractionAnalysisMultiThreaded {
                     + "\tcovariateBeta"
                     + "\tcovariateSE"
                     + "\tinteractionBeta"
-                    + "\tinteractionSE";
-
+                    + "\tinteractionSE"
+                    + "\tinteractionBeta-Flipped";
         }
 
         outputFile.writeln(outputheader);
@@ -725,6 +725,7 @@ public class InteractionAnalysisMultiThreaded {
         double[][] interactionSE = result.getInteractionSE();
         double[][] mainBeta = result.getSNPBeta();
         double[][] mainSE = result.getSNPSE();
+        double[][] rsquared = result.getRsquared();
 
         for (int e = 0; e < eqtls.size(); e++) {
             Pair<String, String> eqtl = eqtls.get(e);
@@ -742,11 +743,24 @@ public class InteractionAnalysisMultiThreaded {
                 builder.append("\t");
                 builder.append(covariateZResultMatrix[e][c]);
                 builder.append("\t");
-                builder.append(interactionZScoreMatrix[e][c]);
+                double interactionZ = interactionZScoreMatrix[e][c];
+                builder.append(interactionZ);
                 builder.append("\t");
-                builder.append(maineffectZResultMatrix[e][c]);
+                double mainZ = maineffectZResultMatrix[e][c];
+                builder.append(mainZ);
+                
+                if(mainZ < 0){
+                    interactionZ*=-1;
+                }
+                builder.append("\t");
+                builder.append(interactionZ);
                 builder.append("\t");
                 builder.append(nMatrix[e][c]);
+                
+                builder.append("\t");
+                builder.append(nMatrix[e][c]);
+                builder.append("\t");
+                builder.append(rsquared[e][c]);
 
                 if (fullStats) {
                     builder.append("\t");
@@ -758,10 +772,17 @@ public class InteractionAnalysisMultiThreaded {
                     builder.append("\t");
                     builder.append(covariateSE[e][c]);
                     builder.append("\t");
-                    builder.append(interactionBeta[e][c]);
+                    double interactionB = interactionBeta[e][c];
+                    builder.append(interactionB);
                     builder.append("\t");
                     builder.append(interactionSE[e][c]);
+                    
+                    if(mainZ<0){
+                        interactionB*=-1;
+                    }
                     builder.append("\t");
+                    builder.append(interactionB);
+                    
                 }
 
                 outputFile.writeln(builder.toString());

--- a/eqtl-mapping-pipeline/src/main/java/eqtlmappingpipeline/interactionanalysis/InteractionAnalysisResults.java
+++ b/eqtl-mapping-pipeline/src/main/java/eqtlmappingpipeline/interactionanalysis/InteractionAnalysisResults.java
@@ -28,8 +28,7 @@ public class InteractionAnalysisResults {
     private final double[][] snpSE;
     private final double[][] covariateBeta;
     private final double[][] covariateSE;
-
-    
+    private final double[][] rsquared;
 
     InteractionAnalysisResults(String qcString,
             ArrayList<Pair<String, String>> eQTLsTested,
@@ -37,7 +36,8 @@ public class InteractionAnalysisResults {
             double[][] SNPZResultMatrix,
             double[][] covariateZResultMatrix,
             double[][] maineffectZResultMatrix,
-            int[][] nMatrix) {
+            int[][] nMatrix,
+            double[][] rsquaredMatrix) {
         this.qcString = qcString;
         this.eQTLsTested = eQTLsTested;
         this.interactionZScoreMatrix = interactionZScoreMatrix;
@@ -45,12 +45,14 @@ public class InteractionAnalysisResults {
         this.covariateZResultMatrix = covariateZResultMatrix;
         this.maineffectZResultMatrix = maineffectZResultMatrix;
         this.nMatrix = nMatrix;
+        this.rsquared = rsquaredMatrix;
         interactionBeta = null;
         interactionSE = null;
         snpBeta = null;
         snpSE = null;
         covariateBeta = null;
         covariateSE = null;
+
     }
 
     InteractionAnalysisResults(String qcString,
@@ -65,7 +67,8 @@ public class InteractionAnalysisResults {
             double[][] mainSE,
             double[][] covariateBeta,
             double[][] covariateSE,
-            int[][] nMatrix) {
+            int[][] nMatrix,
+            double[][] rsquaredMatrix) {
         this.qcString = qcString;
         this.eQTLsTested = eQTLsTested;
         this.interactionZScoreMatrix = interactionZScoreMatrix;
@@ -80,6 +83,7 @@ public class InteractionAnalysisResults {
         this.snpSE = mainSE;
         this.covariateBeta = covariateBeta;
         this.covariateSE = covariateSE;
+        this.rsquared = rsquaredMatrix;
     }
 
     public String getQcString() {
@@ -109,7 +113,7 @@ public class InteractionAnalysisResults {
     public int[][] getnMatrix() {
         return nMatrix;
     }
-    
+
     public double[][] getInteractionBeta() {
         return interactionBeta;
     }
@@ -124,6 +128,10 @@ public class InteractionAnalysisResults {
 
     public double[][] getSNPSE() {
         return snpSE;
+    }
+
+    public double[][] getRsquared() {
+        return rsquared;
     }
 
     public double[][] getCovariateBeta() {


### PR DESCRIPTION
Flips the interaction effect according to the mainZ. MainZ is always relative to minor allele. Flipped effect is in separate output column.
Provides goodness of fit (R-squared) in output
