### PR TITLE
Disabled javadoc lint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,14 @@
 					<artifactId>maven-site-plugin</artifactId>
 					<version>3.3</version>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>2.10.1</version>
+					<configuration>
+						<additionalparam>-Xdoclint:none</additionalparam>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>		
 	</build>


### PR DESCRIPTION
Potential fix for failing build during release. Same problem was encountered with release of molgenis 1.4.0