### PR TITLE
Stabilize subproject versions and their dependencies.

### DIFF
--- a/BinaryMetaAnalyzer/pom.xml
+++ b/BinaryMetaAnalyzer/pom.xml
@@ -7,13 +7,13 @@
         <version>1.0.2</version>
     </parent>
     <artifactId>BinaryMetaAnalyzer</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.7</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>genetica-libraries</artifactId>
-            <version>1.0.7-SNAPSHOT</version>
+            <version>1.0.7</version>
         </dependency>
     </dependencies>
     <name>BinaryMetaAnalyzer</name>

--- a/GeneticRiskScoreCalculator/pom.xml
+++ b/GeneticRiskScoreCalculator/pom.xml
@@ -8,7 +8,7 @@
         <version>1.0.2</version>
     </parent>
     <artifactId>GeneticRiskScoreCalculator</artifactId>
-    <version>0.0.3-SNAPSHOT</version>
+    <version>0.0.3</version>
     <name>Genetic Risk Score Calculator</name>
     <url>http://maven.apache.org</url>
     <properties>

--- a/Genotype-Harmonizer/pom.xml
+++ b/Genotype-Harmonizer/pom.xml
@@ -7,14 +7,14 @@
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>Genotype-Harmonizer</artifactId>
-	<version>1.4.16-SNAPSHOT</version>
+	<version>1.4.16</version>
 	<name>Genotype Harmonizer</name>
 	<packaging>jar</packaging>
 	<dependencies>
 		<dependency>
 			<groupId>nl.systemsgenetics</groupId>
 			<artifactId>Genotype-IO</artifactId>
-			<version>1.0.3-SNAPSHOT</version>
+			<version>1.0.3</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>

--- a/Genotype-IO/pom.xml
+++ b/Genotype-IO/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>Genotype-IO</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.3</version>
 	<packaging>jar</packaging>
 	<dependencies>
 		<dependency>

--- a/cellTypeSpecificAlleleSpecificExpression/pom.xml
+++ b/cellTypeSpecificAlleleSpecificExpression/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>nl.systemsgenetics</groupId>
             <artifactId>Genotype-IO</artifactId>
-            <version>1.0.3-SNAPSHOT</version>
+            <version>1.0.3</version>
             <type>jar</type>
         </dependency>
         <dependency>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>nl.systemsgenetics</groupId>
             <artifactId>genetica-libraries</artifactId>
-            <version>1.0.7-SNAPSHOT</version>
+            <version>1.0.7</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/eQTLInteractionAnalyser/pom.xml
+++ b/eQTLInteractionAnalyser/pom.xml
@@ -7,9 +7,8 @@
 		<artifactId>systemsgenetics</artifactId>
 		<version>1.0.2</version>
 	</parent>
-	<groupId>nl.systemsgenetics</groupId>
 	<artifactId>eQTLInteractionAnalyser</artifactId>
-	<version>1.1-SNAPSHOT</version>
+	<version>1.1</version>
 	<name>eQTLInteractionAnalyser</name>
 	<url>http://maven.apache.org</url>
 	<properties>
@@ -45,7 +44,7 @@
 		<dependency>
 			<groupId>nl.systemsgenetics</groupId>
 			<artifactId>genetica-libraries</artifactId>
-			<version>1.0.7-SNAPSHOT</version>
+			<version>1.0.7</version>
 		</dependency>
 		<dependency>
 			<groupId>com.opencsv</groupId>

--- a/eqtl-functional-enrichment/pom.xml
+++ b/eqtl-functional-enrichment/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>eqtl-functional-enrichment</artifactId>
-	<version>0.0.3-SNAPSHOT</version>
+	<version>0.0.3</version>
 	<name>eqtl-functional-enrichment</name>
 	<packaging>jar</packaging>
 	<dependencies>

--- a/eqtl-mapping-pipeline/pom.xml
+++ b/eqtl-mapping-pipeline/pom.xml
@@ -7,14 +7,14 @@
 		<version>1.0.2</version>
 	</parent>
 	<artifactId>eqtl-mapping-pipeline</artifactId>
-	<version>1.3.5-SNAPSHOT</version>
+	<version>1.3.5</version>
 	<packaging>jar</packaging>
 	<modelVersion>4.0.0</modelVersion>
 	<dependencies>
 		<dependency>
 			<groupId>nl.systemsgenetics</groupId>
 			<artifactId>genetica-libraries</artifactId>
-			<version>1.0.7-SNAPSHOT</version>
+			<version>1.0.7</version>
 		</dependency>
 		<dependency>
 			<groupId>log4j</groupId>
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>nl.systemsgenetics</groupId>
 			<artifactId>Genotype-IO</artifactId>
-			<version>1.0.3-SNAPSHOT</version>
+			<version>1.0.3</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sf.trove4j</groupId>

--- a/genetica-libraries/pom.xml
+++ b/genetica-libraries/pom.xml
@@ -7,7 +7,7 @@
         <version>1.0.2</version>
     </parent>
     <artifactId>genetica-libraries</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.7</version>
     <packaging>jar</packaging>
     <modelVersion>4.0.0</modelVersion>
     <build>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>nl.systemsgenetics</groupId>
             <artifactId>Genotype-IO</artifactId>
-            <version>1.0.3-SNAPSHOT</version>
+            <version>1.0.3</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>

--- a/imputation-tool/pom.xml
+++ b/imputation-tool/pom.xml
@@ -7,7 +7,7 @@
         <version>1.0.2</version>
     </parent>
     <artifactId>imputation-tool</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.4</version>
     <packaging>jar</packaging>
     <modelVersion>4.0.0</modelVersion>
     <dependencies>

--- a/javaPoCA/pom.xml
+++ b/javaPoCA/pom.xml
@@ -7,7 +7,7 @@
         <version>1.0.2</version>
     </parent>
     <artifactId>javaPCoA</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.4</version>
     <packaging>jar</packaging>
     <modelVersion>4.0.0</modelVersion>
     <dependencies>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>nl.systemsgenetics</groupId>
             <artifactId>genetica-libraries</artifactId>
-            <version>1.0.7-SNAPSHOT</version>
+            <version>1.0.7</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.parallelcolt</groupId>


### PR DESCRIPTION
I've left dependencies on previously released versions of GenotypeIO, genetica libraries and imputation-tool in place where they were not referring to the snapshot version.
I noticed that at least one module fails to compile against the most recent version so I didn't want to risk instabilities.