### PR TITLE
Speed improvement to ASreads.

### DIFF
--- a/cellTypeSpecificAlleleSpecificExpression/src/main/java/nl/systemsgenetics/cellTypeSpecificAlleleSpecificExpression/BamOverlapChecker.java
+++ b/cellTypeSpecificAlleleSpecificExpression/src/main/java/nl/systemsgenetics/cellTypeSpecificAlleleSpecificExpression/BamOverlapChecker.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2016 adriaan
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.systemsgenetics.cellTypeSpecificAlleleSpecificExpression;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecordIterator;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.SamReader;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ *
+ * @author adriaan
+ */
+class BamOverlapChecker {
+    
+    
+    
+    int stepSize = 100000;
+    HashMap<String, boolean[]> booleanMap;
+    
+    public BamOverlapChecker(SamReader bam_file){
+        
+        SAMFileHeader  header = bam_file.getFileHeader();
+        SAMSequenceDictionary dict = header.getSequenceDictionary();
+        List<SAMSequenceRecord> sequences = dict.getSequences();
+       
+        
+        booleanMap = new HashMap<String, boolean[]>();
+        
+        for(SAMSequenceRecord sequence : sequences){
+            int sequenceEnd = sequence.getSequenceLength();
+            int arrayLength = (int) Math.ceil( (float) sequenceEnd / (float)stepSize );
+            boolean[] tempArray;
+            tempArray = new boolean[arrayLength];
+            
+            for(int i=0;i<arrayLength;i++){
+                SAMRecordIterator bamQuery = bam_file.queryOverlapping(sequence.getSequenceName(), i*stepSize, (i+1)*stepSize);
+                if(bamQuery.hasNext()){
+                    tempArray[i] = true;
+                }else{
+                    tempArray[i] = false;
+                }
+                bamQuery.close();
+            }
+            booleanMap.put(sequence.getSequenceName(),tempArray );
+            //System.out.println("Finished checking the bam for chromosome " + sequence.getSequenceName());
+        }
+        
+    }
+    
+    public boolean bamHasOverlap(String sequenceName, int position){
+        int indice = (int) Math.floor((double) position / (double) stepSize);
+        return booleanMap.get(sequenceName)[indice];
+    }
+    
+}

--- a/cellTypeSpecificAlleleSpecificExpression/src/main/java/nl/systemsgenetics/cellTypeSpecificAlleleSpecificExpression/FindBamTranscribedRegions.java
+++ b/cellTypeSpecificAlleleSpecificExpression/src/main/java/nl/systemsgenetics/cellTypeSpecificAlleleSpecificExpression/FindBamTranscribedRegions.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2016 adriaan
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.systemsgenetics.cellTypeSpecificAlleleSpecificExpression;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import org.jdom.IllegalDataException;
+
+/**
+ *
+ * @author adriaan
+ * 
+ * This method will read in a .bai index (as an array of bytes)
+ * and it will return a hashmap containing a boolean per binlocation.
+ * 
+ */
+public class FindBamTranscribedRegions {
+    
+    
+    public int num_reference_sequences;
+    
+    public HashMap<String, Boolean> bin_filled = new HashMap<String, Boolean>();
+    public ArrayList<boolean[]> referenceList = new ArrayList<boolean[]>();
+    
+    
+    
+    public FindBamTranscribedRegions(byte[] tabix_bytes) throws IllegalDataException{
+        
+        int iArray = 0;
+        String magic;
+        
+        if( (tabix_bytes[0] != 'B') || 
+            (tabix_bytes[1] != 'A') || 
+            (tabix_bytes[2] != 'I') || 
+            (tabix_bytes[3] != '\1')){
+            throw new IllegalDataException("The tabix magic string did not start with the expected BAI\1 string");
+        }
+        iArray +=4;
+        
+        num_reference_sequences = decode32IntFromArray(tabix_bytes, iArray);
+        iArray +=4;
+        
+        //Do for every chromosome (reference)
+        for(int refs=0; refs < num_reference_sequences; refs++){
+            
+            int empty=0;
+            int full=0;
+            
+            
+            int nBinsThisRef = decode32IntFromArray(tabix_bytes, iArray);
+            iArray+=4;
+            
+            boolean[] tempList = new boolean[37451];
+            for(int n=0; n < 37451; n++){
+                tempList[n] = false;
+            }
+            
+            //do for every bin in the chromosome (reference)
+            for(int refBins=0; refBins < nBinsThisRef; refBins++ ){
+                //no need to do anything for the bin 37450, as it will be processed correctly.
+               
+                int bin = (int) decode32uIntFromArray(tabix_bytes, iArray);
+                iArray +=4;
+                
+                int n_chunks = decode32IntFromArray(tabix_bytes, iArray);
+                iArray +=4;
+                
+                byte[] startValue = Arrays.copyOfRange(tabix_bytes, iArray, iArray+8);
+                byte[] endValue   = Arrays.copyOfRange(tabix_bytes, iArray + 16*(n_chunks-1), iArray + 16*(n_chunks-1)+ 8);
+                iArray += 16*n_chunks;
+                
+                //if the bin is empty, show it.
+                if(Arrays.equals(startValue,endValue)){
+                    tempList[bin] = true;
+                    empty++;
+                }else{
+                    tempList[bin] = false;
+                    full++;
+                }
+                
+            }
+            
+            int num_intervals = decode32IntFromArray(tabix_bytes, iArray);
+            iArray+=4;
+            iArray+= num_intervals*8;
+            
+            referenceList.add(tempList);
+            
+            //System.out.printf("If I'm correct. Sequence %d contains %d empty and %d full bins.\n", refs, empty, full );
+        }
+        
+        
+       
+        
+    }
+            
+    
+    //adapted from SO: stackoverflow.com/questions/23417810/encoding-int32-t-to-a-byte-array
+    public static int decode32IntFromArray(byte[] array, int pos)
+    {
+        return (int)
+                (
+                        ((array[pos+3] & 0xFF) << 24) 
+                    +   ((array[pos+2] & 0xFF) << 16)                 
+                    +   ((array[pos+1] & 0xFF) << 8) 
+                    +   ((array[pos+0] & 0xFF))
+                );        
+    }
+    
+    public static long decode32uIntFromArray(byte[] array, int pos)
+    {
+        return (long)
+                (
+                        ((array[pos+3] & 0xFF) << 24) 
+                    +   ((array[pos+2] & 0xFF) << 16)                 
+                    +   ((array[pos+1] & 0xFF) << 8) 
+                    +   ((array[pos+0] & 0xFF))
+                );        
+    }
+    
+
+    //taken from the sam specification sheet.
+    private static int reg2bin(int begin, int end)
+    {
+        --end;
+        if (begin>>14 == end>>14) return ((1<<15)-1)/7 + (begin>>14);
+        if (begin>>17 == end>>17) return ((1<<12)-1)/7 + (begin>>17);
+        if (begin>>20 == end>>20) return ((1<<9)-1)/7 + (begin>>20);
+        if (begin>>23 == end>>23) return ((1<<6)-1)/7 + (begin>>23);
+        if (begin>>26 == end>>26) return ((1<<3)-1)/7 + (begin>>26);
+        return 0;
+    }
+    
+    public boolean bamHasOverlap(int reference, int bpPosition){
+        return !(referenceList.get(reference)[reg2bin(bpPosition-1, bpPosition+1)]);
+    }
+    
+}

--- a/cellTypeSpecificAlleleSpecificExpression/src/main/java/nl/systemsgenetics/cellTypeSpecificAlleleSpecificExpression/ReadGenoAndAsFromIndividual.java
+++ b/cellTypeSpecificAlleleSpecificExpression/src/main/java/nl/systemsgenetics/cellTypeSpecificAlleleSpecificExpression/ReadGenoAndAsFromIndividual.java
@@ -19,9 +19,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.Arrays;
+import java.io.InputStream;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Set;
 import java.util.ArrayList;
@@ -33,6 +37,7 @@ import org.molgenis.genotype.variant.GeneticVariant;
 import org.molgenis.genotype.vcf.VcfGenotypeData;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
 
 import org.jdom.IllegalDataException;
 
@@ -70,12 +75,12 @@ public class ReadGenoAndAsFromIndividual {
         
 
         //parse command line arguments
-        String loc_of_bam;
-        loc_of_bam = loc_of_bam1;
+        String LocOfBam;
+        LocOfBam = loc_of_bam1;
         System.out.println("Location of bam file: ");
-        System.out.println(loc_of_bam);
+        System.out.println(LocOfBam);
         
-        if (!new File(loc_of_bam).exists()){
+        if (!new File(LocOfBam).exists()){
            throw new IllegalArgumentException("ERROR! Location of bam file is not an existing file. Exitting.");
         }else{
             if(GlobalVariables.verbosity >= 10){
@@ -153,7 +158,7 @@ public class ReadGenoAndAsFromIndividual {
                 SNPsToAnalyze.add(snp_to_include);
             }
         }
-        
+        int totalSnps = SNPsToAnalyze.size();
        
         //String path = "/gcc/groups/lld/tmp01/projects/bamFiles/";
         //sample_map contains all the individuals that are in the sample file.
@@ -167,7 +172,7 @@ public class ReadGenoAndAsFromIndividual {
         }
        
         //Twice because my files have the .MERGED.sorted.bam suffix attached to them.
-        String sample_name = FilenameUtils.getBaseName(FilenameUtils.getBaseName(FilenameUtils.getBaseName(loc_of_bam)));
+        String sample_name = FilenameUtils.getBaseName(FilenameUtils.getBaseName(FilenameUtils.getBaseName(LocOfBam)));
         
         if(GlobalVariables.verbosity >= 10){
             System.out.println("sample_name: " + sample_name);
@@ -187,8 +192,7 @@ public class ReadGenoAndAsFromIndividual {
         }
         
         //bam file path and filename
-        String path_and_filename = loc_of_bam;
-        File sample_file = new File(path_and_filename);
+        File sample_file = new File(LocOfBam);
 
         PrintWriter writer = new PrintWriter(outputLocation, "UTF-8");
         SamReader bam_file = SamReaderFactory.makeDefault().open(sample_file);
@@ -198,21 +202,25 @@ public class ReadGenoAndAsFromIndividual {
         }
         
         
+
+        InputStream IndexInputStream = new FileInputStream(LocOfBam+ ".bai");
+        byte[] indexFileByteArray = IOUtils.toByteArray(IndexInputStream);
+        FindBamTranscribedRegions checkRegion;
+        checkRegion = new FindBamTranscribedRegions(indexFileByteArray);
+ 
         
-        
-        
-        
-        
+        //iterate over all snps
         int i = 0;
         for(String i_snp : SNPsToAnalyze){
             
-            //System.out.println(i_snp);
             
-            GeneticVariant this_variant = variantIdMap.get(i_snp);
             
-            String chromosome = this_variant.getSequenceName();
-            String position = String.valueOf(this_variant.getStartPos());
+            GeneticVariant thisVariant = variantIdMap.get(i_snp);
             
+            
+            String chromosome = thisVariant.getSequenceName();
+            String position = String.valueOf(thisVariant.getStartPos());
+          
 
             
             // We only do analyses if we find a SNP and it is biallelic
@@ -220,35 +228,53 @@ public class ReadGenoAndAsFromIndividual {
             // the allele count is used for the check of something. 
             
             
-            if(this_variant.isSnp() & this_variant.isBiallelic() ){
-
-                String row_of_table = get_allele_specific_overlap_at_snp(this_variant, 
-                                                                        sample_index,
-                                                                        chromosome,
-                                                                        position,
-                                                                        bam_file);
-                 
+            if(thisVariant.isSnp() & thisVariant.isBiallelic() ){
                 
-                //commented out the phasing part.
-                
-                writer.println(chromosome + "\t" + position + "\t" + i_snp + "\t" + 
-                               this_variant.getVariantAlleles().getAllelesAsChars()[0] + "\t" +
-                               this_variant.getVariantAlleles().getAllelesAsChars()[1] + "\t" +
-                               row_of_table + "\t" + 
-                               Arrays.toString(this_variant.getSampleVariants().get(sample_index).getAllelesAsChars()) //+ "\t" +
+                  
+                if(!checkRegion.bamHasOverlap(Integer.parseInt(chromosome), thisVariant.getStartPos())){
+                    
+                    writer.println(chromosome + "\t" + position + "\t" + i_snp + "\t" + 
+                               thisVariant.getVariantAlleles().getAllelesAsChars()[0] + "\t" +
+                               thisVariant.getVariantAlleles().getAllelesAsChars()[1] + "\t" +
+                               "0\t0\t0" + "\t" + 
+                               Arrays.toString(thisVariant.getSampleVariants().get(sample_index).getAllelesAsChars()) //+ "\t" +
                                //Boolean.toString(this_variant.getSamplePhasing().get(sample_index))
                             );
+
+                }else{
+                
+                
+                    String row_of_table = get_allele_specific_overlap_at_snp(thisVariant, 
+                                                                            sample_index,
+                                                                            chromosome,
+                                                                            position,
+                                                                            bam_file);
+
+
+                    //commented out the phasing part.
+
+                    writer.println(chromosome + "\t" + position + "\t" + i_snp + "\t" + 
+                                   thisVariant.getVariantAlleles().getAllelesAsChars()[0] + "\t" +
+                                   thisVariant.getVariantAlleles().getAllelesAsChars()[1] + "\t" +
+                                   row_of_table + "\t" + 
+                                   Arrays.toString(thisVariant.getSampleVariants().get(sample_index).getAllelesAsChars()) //+ "\t" +
+                                   //Boolean.toString(this_variant.getSamplePhasing().get(sample_index))
+                                );
+                }
             }
          
             i++;
             
             if((i % 10000 == 0) && (GlobalVariables.verbosity >= 10)){
 
-                System.out.println("Finished " + Integer.toString(i) + " SNPs");
+                System.out.printf("Finished %d (%3.1f %%) SNPs\r", i, (double)i / (double)totalSnps * 100.0 );
             
             }
-        
         }
+        
+        System.out.println("Finished ASreads for: " + loc_of_bam1);
+        System.out.println("Output is located in: " + outputLocation);
+        
         writer.close();
     }
     
@@ -313,13 +339,10 @@ public class ReadGenoAndAsFromIndividual {
             
             SAMRecord read_in_region = all_reads_in_region.next();
             
-            
             Character base_in_read = get_base_at_position(read_in_region, pos_int);
             if(GlobalVariables.verbosity >= 100){
                 System.out.println("base_in_read: " + base_in_read);
             }
-            
-            
             
             if( base_in_read == ref_allele.charAt(0) ){
                 ref_overlap++;            
@@ -329,12 +352,8 @@ public class ReadGenoAndAsFromIndividual {
                 continue;
             }else{
                 no__overlap++;
-            
             }
-            
-            
         }
-        
         
         //This line below cost me a day to figure out the error.
         all_reads_in_region.close();

--- a/cellTypeSpecificAlleleSpecificExpression/src/main/java/nl/systemsgenetics/cellTypeSpecificAlleleSpecificExpression/ReadGenoAndAsFromIndividual.java
+++ b/cellTypeSpecificAlleleSpecificExpression/src/main/java/nl/systemsgenetics/cellTypeSpecificAlleleSpecificExpression/ReadGenoAndAsFromIndividual.java
@@ -7,7 +7,12 @@
 package nl.systemsgenetics.cellTypeSpecificAlleleSpecificExpression;
 
 
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordIterator;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.CigarElement;
+
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.File;
@@ -15,23 +20,21 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
+import java.io.PrintWriter;
 
 import java.util.HashMap;
-
 import java.util.Set;
+import java.util.ArrayList;
+
 import org.molgenis.genotype.Alleles;
 import org.molgenis.genotype.RandomAccessGenotypeData;
 import org.molgenis.genotype.trityper.TriTyperGenotypeData;
 import org.molgenis.genotype.variant.GeneticVariant;
-import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SAMRecordIterator;
-import htsjdk.samtools.SamReader;
-import htsjdk.samtools.SamReaderFactory;
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import org.apache.commons.io.FilenameUtils;
-import org.jdom.IllegalDataException;
 import org.molgenis.genotype.vcf.VcfGenotypeData;
+
+import org.apache.commons.io.FilenameUtils;
+
+import org.jdom.IllegalDataException;
 
 
 
@@ -47,7 +50,7 @@ public class ReadGenoAndAsFromIndividual {
                                                    String outputLocation, 
                                                    String snpLocation) throws IOException, Exception{
         
-        if(GlobalVariables.verbosity >= 1){
+        if(GlobalVariables.verbosity >= 10){
             //Print ASREADS header
             System.out.println(    "---- Starting ASREADS for the following settings: ----");
             System.out.println(    "\t input bam:         " +  loc_of_bam1);
@@ -132,11 +135,8 @@ public class ReadGenoAndAsFromIndividual {
         
         //If available, read the file with rs numbers.
         if(!snpLocation.equals("")){
-            
             ArrayList<String>  includeSNPs = UtilityMethods.readFileIntoStringArrayList(snpLocation);
-            
             int snpsNotFound = 0;
-            
             for(String snp_to_include : includeSNPs){
                 if(snpNames.contains(snp_to_include)){
                     SNPsToAnalyze.add(snp_to_include);
@@ -190,13 +190,17 @@ public class ReadGenoAndAsFromIndividual {
         String path_and_filename = loc_of_bam;
         File sample_file = new File(path_and_filename);
 
+        PrintWriter writer = new PrintWriter(outputLocation, "UTF-8");
         SamReader bam_file = SamReaderFactory.makeDefault().open(sample_file);
 
         if(GlobalVariables.verbosity >= 10){
             System.out.println("Initialized for reading bam file");
         }
         
-        PrintWriter writer = new PrintWriter(outputLocation, "UTF-8");
+        
+        
+        
+        
         
         
         int i = 0;
@@ -216,7 +220,6 @@ public class ReadGenoAndAsFromIndividual {
             // the allele count is used for the check of something. 
             
             
-            //DO NOT ENTER A SEPARATED GENOMIC DATASET OTHERWISE THIS WILL BREAK.
             if(this_variant.isSnp() & this_variant.isBiallelic() ){
 
                 String row_of_table = get_allele_specific_overlap_at_snp(this_variant, 


### PR DESCRIPTION
I've implemented a method that will improve the speed of ASreads, 
by first querying the bam index if a region contains transcripts. 
This produces around a 5% speed improvement.  
I've also tried to bin up the genome in small chunks, and query that,
but it was not more efficient than the method without speed improvements.
Overhead of the method implemented here is minimal.