### PR TITLE
Fix for mvn site goal

### DIFF
--- a/Decon2/Decon-eQTL/pom.xml
+++ b/Decon2/Decon-eQTL/pom.xml
@@ -1,5 +1,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>nl.systemsgenetics</groupId>
+        <artifactId>systemsgenetics</artifactId>
+        <version>1.0.4-SNAPSHOT</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>Decon-eQTL</groupId>
     <artifactId>Decon-eQTL</artifactId>

--- a/Genotype-IO/pom.xml
+++ b/Genotype-IO/pom.xml
@@ -112,8 +112,8 @@
                 <version>3.8.1</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -149,9 +149,9 @@
                     <execution>
                         <phase>process-test-resources</phase>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <copy file="src/test/resources/bgenExamples/example.16bits.bgen" todir="${project.build.testOutputDirectory}/bgenExamples" preservelastmodified="true"/>
-                            </tasks>
+                            </target>
                         </configuration>
                         <goals>
                             <goal>run</goal>
@@ -184,7 +184,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.10</version>
                         <configuration>
-                            <encoding>UTF-8</encoding>
                             <suiteXmlFiles>
                                 <suiteXmlFile>target/nb-private/testng-suite.xml</suiteXmlFile>
                             </suiteXmlFiles>

--- a/eqtl-mapping-pipeline/pom.xml
+++ b/eqtl-mapping-pipeline/pom.xml
@@ -170,6 +170,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
+                    <encoding>UTF-8</encoding>
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,6 @@
         that is used for determining the covarage (this is used on the Jenkins server). -->
     <dependencies>
         <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
-            <version>5.0.3</version>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.1.2</version>
@@ -47,10 +42,6 @@
                     <artifactId>tools</artifactId>
                     <groupId>com.sun</groupId>
                 </exclusion>
-<!--                <exclusion>-->
-<!--                    <groupId>org.slf4j</groupId>-->
-<!--                    <artifactId>slf4j-log4j12</artifactId>-->
-<!--                </exclusion>-->
             </exclusions>
         </dependency>
     </dependencies>
@@ -122,11 +113,6 @@
                 <configuration>
                     <xmlOutput>true</xmlOutput>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.8.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,44 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
+<!--    Added the following dependencies to circumvent difficulties when using the cobertura-maven-plugin
+        that is used for determining the covarage (this is used on the Jenkins server). -->
+    <dependencies>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>5.0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.cobertura</groupId>
+            <artifactId>cobertura</artifactId>
+            <version>2.1.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>tools</artifactId>
+                    <groupId>com.sun</groupId>
+                </exclusion>
+<!--                <exclusion>-->
+<!--                    <groupId>org.slf4j</groupId>-->
+<!--                    <artifactId>slf4j-log4j12</artifactId>-->
+<!--                </exclusion>-->
+            </exclusions>
+        </dependency>
+    </dependencies>
     <build>
         <pluginManagement>
             <plugins>
@@ -35,7 +73,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.8.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -73,6 +111,7 @@
                         <format>html</format>
                         <format>xml</format>
                     </formats>
+                    <check/>
                 </configuration>
             </plugin>
             <!-- code analysis -->
@@ -83,6 +122,16 @@
                 <configuration>
                     <xmlOutput>true</xmlOutput>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.8.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>3.0.0</version>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION
Adapted POMs for various modules for successful (local) site generation.
Includes a workaround for the cobertura coverage tool not using correct dependencies causing
cryptic errors.
Additionally the Decon-eQTL module now has systemsgenetics as its parent module