### PR TITLE
Fix for parent pom of Decon-eQTL not being found

### DIFF
--- a/Decon2/Decon-eQTL/pom.xml
+++ b/Decon2/Decon-eQTL/pom.xml
@@ -4,6 +4,7 @@
         <groupId>nl.systemsgenetics</groupId>
         <artifactId>systemsgenetics</artifactId>
         <version>1.0.4-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>Decon-eQTL</groupId>


### PR DESCRIPTION
Added relative path directed to systemsgenetics pom in Decon-eQTL module pom