### PR TITLE
Preferred genotype field for VCF files

### DIFF
--- a/Genotype-Harmonizer/src/main/java/nl/umcg/deelenp/genotypeharmonizer/GenotypeHarmonizer.java
+++ b/Genotype-Harmonizer/src/main/java/nl/umcg/deelenp/genotypeharmonizer/GenotypeHarmonizer.java
@@ -17,11 +17,7 @@ import org.apache.log4j.FileAppender;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.SimpleLayout;
-import org.molgenis.genotype.GenotypeDataException;
-import org.molgenis.genotype.GenotypeWriter;
-import org.molgenis.genotype.GenotypedDataWriterFormats;
-import org.molgenis.genotype.RandomAccessGenotypeData;
-import org.molgenis.genotype.RandomAccessGenotypeDataReaderFormats;
+import org.molgenis.genotype.*;
 import org.molgenis.genotype.modifiable.ModifiableGenotypeData;
 import org.molgenis.genotype.multipart.IncompatibleMultiPartGenotypeDataException;
 import org.molgenis.genotype.sampleFilter.SampleIdIncludeFilter;
@@ -249,6 +245,17 @@ class GenotypeHarmonizer {
 			}
 		}
 
+		if (parameters.getVcfGenotypeFormatSupplier() != null && (
+				parameters.getInputType() != RandomAccessGenotypeDataReaderFormats.VCF &&
+				parameters.getInputType() != RandomAccessGenotypeDataReaderFormats.VCF_FOLDER)) {
+			String errorMessage = String.format(
+					"GenotypeField can only be set for the VCF input type, not for '%s'",
+					parameters.getInputType().getName());
+			LOGGER.fatal(errorMessage);
+			System.err.println(errorMessage);
+			System.exit(1);
+		}
+
 		SampleIdIncludeFilter sampleFilter = null;
 
 		if (parameters.getSampleFilterListFile() != null) {
@@ -275,7 +282,7 @@ class GenotypeHarmonizer {
 		final RandomAccessGenotypeData inputData;
 
 		try {
-			inputData = parameters.getInputType().createFilteredGenotypeData(parameters.getInputBasePaths(), genotypeDataCache, varFilter, sampleFilter, parameters.getForceSeqName(), parameters.getMinimumPosteriorProbability());
+			inputData = parameters.getInputType().createFilteredGenotypeData(parameters.getInputBasePaths(), genotypeDataCache, varFilter, sampleFilter, parameters.getForceSeqName(), parameters.getVcfGenotypeFormatSupplier(), parameters.getMinimumPosteriorProbability());
 		} catch (TabixFileNotFoundException e) {
 			System.err.println("Tabix file not found for input data at: " + e.getPath() + "\n"
 					+ "Please see README on how to create a tabix file");

--- a/Genotype-IO/src/main/java/org/molgenis/genotype/GenotypeInfo.java
+++ b/Genotype-IO/src/main/java/org/molgenis/genotype/GenotypeInfo.java
@@ -27,6 +27,7 @@ import org.molgenis.genotype.tabix.TabixFileNotFoundException;
 import org.molgenis.genotype.util.GenotypeCountCalculator;
 import org.molgenis.genotype.variant.GeneticVariant;
 import org.molgenis.genotype.variantFilter.VariantFilterSeqPos;
+import org.molgenis.genotype.vcf.VcfGenotypeField.VcfGenotypeFormatSupplier;
 
 /**
  *
@@ -225,7 +226,8 @@ public class GenotypeInfo {
 			final RandomAccessGenotypeData inputData;
 
 			try {
-				inputData = inputType.createFilteredGenotypeData(inputBasePaths, 0, varFilter, sampleFilter, forceSeqName, minimumPosteriorProbability);
+				final VcfGenotypeFormatSupplier vcfGenotypeFormatSupplier = null;
+				inputData = inputType.createFilteredGenotypeData(inputBasePaths, 0, varFilter, sampleFilter, forceSeqName, vcfGenotypeFormatSupplier, minimumPosteriorProbability);
 			} catch (TabixFileNotFoundException e) {
 				LOGGER.fatal("Tabix file not found for input data at: " + e.getPath() + "\n"
 						+ "Please see README on how to create a tabix file");

--- a/Genotype-IO/src/main/java/org/molgenis/genotype/multipart/MultiPartGenotypeData.java
+++ b/Genotype-IO/src/main/java/org/molgenis/genotype/multipart/MultiPartGenotypeData.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -26,6 +25,7 @@ import org.molgenis.genotype.annotation.SampleAnnotation;
 import org.molgenis.genotype.oxford.GenGenotypeData;
 import org.molgenis.genotype.variant.GeneticVariant;
 import org.molgenis.genotype.vcf.VcfGenotypeData;
+import org.molgenis.genotype.vcf.VcfGenotypeField.VcfGenotypeFormatSupplier;
 
 public class MultiPartGenotypeData extends AbstractRandomAccessGenotypeData
 {
@@ -122,22 +122,25 @@ public class MultiPartGenotypeData extends AbstractRandomAccessGenotypeData
 		this.genotypeDataCollection = genotypeDataCollection;
 	}
 
-	/**
-	 * Folder with VCF files. Matches all vcf.gz (case insensitive). Can only
-	 * handle one file per chr. vcf.gz.tbi should be present. All files must
-	 * have the same samples in the same order.
-	 * 
-	 * @param vcfFolder
-	 *            folder with vcf files
-	 * @param cacheSize
-	 *            size of the cache per vcf file.
-	 * @throws IOException
-	 * @throws IncompatibleMultiPartGenotypeDataException
-	 *             if the datasets are not compatible
-	 * @throws Exception
-	 *             If multiple files for one chr found
-	 */
 	public static MultiPartGenotypeData createFromVcfFolder(File vcfFolder, int cacheSize, double minimumPosteriorProbabilityToCall) throws IOException,
+			IncompatibleMultiPartGenotypeDataException
+	{
+		return createFromVcfFolder(vcfFolder, cacheSize, null, minimumPosteriorProbabilityToCall);
+	}
+
+	/**
+     * Folder with VCF files. Matches all vcf.gz (case insensitive). Can only
+     * handle one file per chr. vcf.gz.tbi should be present. All files must
+     * have the same samples in the same order.
+     *
+     * @param vcfFolder                 folder with vcf files
+     * @param cacheSize                 size of the cache per vcf file.
+     * @param vcfGenotypeFormatSupplier
+     * @throws IOException
+     * @throws IncompatibleMultiPartGenotypeDataException if the datasets are not compatible
+     * @throws Exception                                  If multiple files for one chr found
+     */
+	public static MultiPartGenotypeData createFromVcfFolder(File vcfFolder, int cacheSize, VcfGenotypeFormatSupplier vcfGenotypeFormatSupplier, double minimumPosteriorProbabilityToCall) throws IOException,
 			IncompatibleMultiPartGenotypeDataException
 	{
 
@@ -159,7 +162,11 @@ public class MultiPartGenotypeData extends AbstractRandomAccessGenotypeData
 			if (matcher.matches())
 			{
 				//LOGGER.debug("Adding to multipart data: " + file.getAbsolutePath());
-				genotypeDataSets.add(new VcfGenotypeData(file, cacheSize, minimumPosteriorProbabilityToCall));
+				VcfGenotypeData vcfGenotypeData = new VcfGenotypeData(file, cacheSize, minimumPosteriorProbabilityToCall);
+				if (vcfGenotypeFormatSupplier != null) {
+					vcfGenotypeData.setPreferredGenotypeFormat(vcfGenotypeFormatSupplier);
+				}
+				genotypeDataSets.add(vcfGenotypeData);
 			} 
 		}
 		

--- a/Genotype-IO/src/main/java/org/molgenis/genotype/vcf/VcfGenotypeData.java
+++ b/Genotype-IO/src/main/java/org/molgenis/genotype/vcf/VcfGenotypeData.java
@@ -984,15 +984,31 @@ public class VcfGenotypeData extends AbstractRandomAccessGenotypeData implements
                 VcfGenotypeFormat.valueOf(preferredGenotypeFormat) : null));
     }
 
+    public void setPreferredGenotypeFormat(String preferredGenotypeFormat, boolean raiseExceptionIfUnavailable) {
+        this.setPreferredGenotypeFormat(
+                new VcfGenotypeFormatSupplier(preferredGenotypeFormat != null ?
+                        VcfGenotypeFormat.valueOf(preferredGenotypeFormat) : null, raiseExceptionIfUnavailable));
+    }
+
     public VcfGenotypeFormatSupplier getPreferredGenotypeFormat() {
         return genotypeFormatSupplier;
     }
 
-    public void setPreferredGenotypeFormat(VcfGenotypeFormat preferredGenotypeField, String fieldIdentifier) {
-        this.setPreferredGenotypeFormat(new VcfGenotypeFormatSupplier(preferredGenotypeField, fieldIdentifier));
+    public void setPreferredGenotypeFormat(
+            VcfGenotypeFormat preferredGenotypeField, String fieldIdentifier, boolean raiseExceptionIfUnavailable) {
+        this.setPreferredGenotypeFormat(new VcfGenotypeFormatSupplier(
+                preferredGenotypeField, fieldIdentifier,
+                raiseExceptionIfUnavailable));
+    }
+
+    public void setPreferredGenotypeFormat(
+            VcfGenotypeFormat preferredGenotypeField, String fieldIdentifier) {
+        this.setPreferredGenotypeFormat(new VcfGenotypeFormatSupplier(
+                preferredGenotypeField, fieldIdentifier));
     }
 
     public void setPreferredGenotypeFormat(VcfGenotypeFormatSupplier genotypeFormatSupplier) {
         this.genotypeFormatSupplier = genotypeFormatSupplier;
     }
+
 }

--- a/Genotype-IO/src/main/java/org/molgenis/genotype/vcf/VcfGenotypeField/VcfGenotypeFormatSupplier.java
+++ b/Genotype-IO/src/main/java/org/molgenis/genotype/vcf/VcfGenotypeField/VcfGenotypeFormatSupplier.java
@@ -1,5 +1,7 @@
 package org.molgenis.genotype.vcf.VcfGenotypeField;
 
+import org.apache.commons.lang3.StringUtils;
+import org.molgenis.genotype.GenotypeDataException;
 import org.molgenis.vcf.VcfRecord;
 
 import java.util.Arrays;
@@ -13,19 +15,29 @@ import java.util.List;
 public class VcfGenotypeFormatSupplier {
     private VcfGenotypeFormat preferredGenotypeFormat;
     private String preferredGenotypeFormatIdentifier;
+    private boolean raiseExceptionIfUnavailable;
 
     public VcfGenotypeFormatSupplier(VcfGenotypeFormat preferredGenotypeFormat) {
-        this(preferredGenotypeFormat, preferredGenotypeFormat.toString());
+        this(preferredGenotypeFormat, preferredGenotypeFormat.toString(), false);
     }
 
     public VcfGenotypeFormatSupplier(VcfGenotypeFormat preferredGenotypeFormat, String formatIdentifier) {
+        this(preferredGenotypeFormat, formatIdentifier, false);
+    }
+
+    public VcfGenotypeFormatSupplier(VcfGenotypeFormat preferredGenotypeFormat, boolean raiseExceptionIfUnavailable) {
+        this(preferredGenotypeFormat, preferredGenotypeFormat.toString(), false);
+    }
+
+    public VcfGenotypeFormatSupplier(VcfGenotypeFormat preferredGenotypeFormat, String formatIdentifier, boolean raiseExceptionIfUnavailable) {
 
         this.preferredGenotypeFormat = preferredGenotypeFormat;
         this.preferredGenotypeFormatIdentifier = formatIdentifier;
+        this.raiseExceptionIfUnavailable = raiseExceptionIfUnavailable;
     }
 
     public VcfGenotypeFormatSupplier() {
-        this(null, null);
+        this(null, null, false);
     }
 
     /**
@@ -47,6 +59,16 @@ public class VcfGenotypeFormatSupplier {
                 && genotypeDosageFieldPrecedence.contains(preferredGenotypeFormat)
                 && formatIdentifiers.contains(this.getGenotypeFormatIdentifier(preferredGenotypeFormat))) {
             return preferredGenotypeFormat;
+        }
+
+        if (this.raiseExceptionIfUnavailable) {
+            throw new GenotypeDataException(String.format(
+                    "Preferred genotype format field (%s) is unavailable for vcf record: %n%s (%s:%s). " +
+                            "Available format fields: %s",
+                    preferredGenotypeFormatIdentifier,
+                    String.join(", ", vcfRecord.getIdentifiers()),
+                    vcfRecord.getChromosome(), vcfRecord.getPosition(),
+                    String.join(", ", vcfRecord.getFormat())));
         }
 
         for (VcfGenotypeFormat genotypeFormat: genotypeDosageFieldPrecedence) {


### PR DESCRIPTION
Made it possible to request a preferred genotype format field for reading genotypes from a VCF file through GenotypeHarmonizer.

--genotypeField/-gf can be used as per the help message:

`
-gf,--genotypeField <string>          Preferred VCF genotype format field
                                       to read. A maximum of three
                                       arguments are used. The first
                                       argument should always be one of
                                       the supported genotype fields (GT,
                                       GP, HP, DS or ADS). If the
                                       preferred genotype field defined
                                       within the input VCF is not within
                                       this list, but is synonymous to one
                                       of them, the optional second
                                       argument should match the genotype
                                       field defined in the VCF. The third
                                       variable can be used to suppress an
                                       exception whenever a the requested
                                       genotype field is unavailable (for
                                       a given variant): 'suppress' Option
                                       only valid in combination with
                                       --inputType VCF
`