### PR TITLE
Changed mvn plugin configurations in Genotype-Harmonizer and Genotype…

### DIFF
--- a/Genotype-Harmonizer/pom.xml
+++ b/Genotype-Harmonizer/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>Genotype-Harmonizer</artifactId>
-	<version>1.4.24-SNAPSHOT</version>
+	<version>1.4.25-SNAPSHOT</version>
 	<name>Genotype Harmonizer</name>
 	<packaging>jar</packaging>
 	<dependencies>
@@ -111,10 +111,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.8.1</version>
 				<configuration>
-					<source>8</source>
-					<target>8</target>
+					<release>8</release>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/Genotype-IO/pom.xml
+++ b/Genotype-IO/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>Genotype-IO</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -100,8 +100,7 @@
                 <version>3.8.1</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>8</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/Genotype-IO/pom.xml
+++ b/Genotype-IO/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>Genotype-IO</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.6-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
…-IO to use '--release 8' instead of '--source 1.8 --target 1.8'. This resolves issues with Java APIs that changed over versions (e.g. ByteBuffer.flip()). Also version bump in both modules.