### PR TITLE
Bug fixes and minor improvements to Genotype-IO and GH

### DIFF
--- a/Genotype-Harmonizer/pom.xml
+++ b/Genotype-Harmonizer/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>Genotype-Harmonizer</artifactId>
-	<version>1.4.25-SNAPSHOT</version>
+	<version>1.4.26-SNAPSHOT</version>
 	<name>Genotype Harmonizer</name>
 	<packaging>jar</packaging>
 	<dependencies>

--- a/Genotype-Harmonizer/src/main/java/nl/umcg/deelenp/genotypeharmonizer/GenotypeHarmonizerParamaters.java
+++ b/Genotype-Harmonizer/src/main/java/nl/umcg/deelenp/genotypeharmonizer/GenotypeHarmonizerParamaters.java
@@ -441,12 +441,12 @@ public class GenotypeHarmonizerParamaters {
                         + "\" is not a supported genotype field.");
             }
 
-            boolean raiseExceptionIfUnavailable = true;
+            boolean forcePreferredGenotypeFormat = true;
             if (genotypeFormatArguments.length > 2) {
                 if (genotypeFormatArguments[2].equals("suppress")) {
                     System.out.println("WARNING: requested to supress exceptions if preferred genotype format is unavailable. For those variants the default will be chosen.");
                     LOGGER.warn("WARNING: requested to supress exceptions if preferred genotype format is unavailable. For those variants the default will be chosen.");
-                    raiseExceptionIfUnavailable = false;
+                    forcePreferredGenotypeFormat = false;
                 }
             }
 
@@ -454,7 +454,7 @@ public class GenotypeHarmonizerParamaters {
                     VcfGenotypeFormat.valueOf(genotypeFormatArguments[0]),
                     genotypeFormatArguments.length > 1 ?
                             genotypeFormatArguments[1] : genotypeFormatArguments[0],
-                    raiseExceptionIfUnavailable);
+                    forcePreferredGenotypeFormat);
         }
 
         vcfGenotypeFormatSupplier = nonFinalVcfGenotypeFormatSupplier;

--- a/Genotype-IO/src/main/java/org/molgenis/genotype/bgen/BgenGenotypeWriter.java
+++ b/Genotype-IO/src/main/java/org/molgenis/genotype/bgen/BgenGenotypeWriter.java
@@ -301,8 +301,7 @@ public class BgenGenotypeWriter implements GenotypeWriter {
 		byte[] firstBytes = new byte[1000];
 		randomAccessBgenFile.read(firstBytes, 0, 1000);
 
-		//Add current time in int.
-		System.out.println((System.currentTimeMillis() / 1000L));
+		// Add current time in int.
 		// Create and write new metadata.
 		BgenixMetadata m = new BgenixMetadata(
 				bgenFile.getName(),

--- a/Genotype-IO/src/main/java/org/molgenis/genotype/vcf/VcfGenotypeData.java
+++ b/Genotype-IO/src/main/java/org/molgenis/genotype/vcf/VcfGenotypeData.java
@@ -324,7 +324,7 @@ public class VcfGenotypeData extends AbstractRandomAccessGenotypeData implements
         LinkedHashSet<VcfGenotypeFormat> haplotypeProbabilitiesFields = getVcfHaplotypeFormats(variant);
 
         // If the requested format is set and present for this variant base decision on this format
-        return genotypeFormatSupplier.VcfGenotypeFormatReadable(
+        return genotypeFormatSupplier.vcfGenotypeFormatReadable(
                 vcfRecord, haplotypeProbabilitiesFields);
     }
 

--- a/Genotype-IO/src/main/java/org/molgenis/genotype/vcf/VcfGenotypeData.java
+++ b/Genotype-IO/src/main/java/org/molgenis/genotype/vcf/VcfGenotypeData.java
@@ -65,6 +65,7 @@ public class VcfGenotypeData extends AbstractRandomAccessGenotypeData implements
     private final LinkedHashSet<VcfGenotypeFormat> genotypeProbabilitiesFieldPrecedence;
     private final LinkedHashSet<VcfGenotypeFormat> genotypeCallFieldPrecedence;
     private final LinkedHashSet<VcfGenotypeFormat> genotypeDosageFieldPrecedence;
+    private final LinkedHashSet<VcfGenotypeFormat> haplotypeProbabilitiesFieldPresedence;
 
 
     /**
@@ -138,6 +139,8 @@ public class VcfGenotypeData extends AbstractRandomAccessGenotypeData implements
                 new LinkedHashSet<>(Arrays.asList(VcfGenotypeFormat.GT, VcfGenotypeFormat.GP, VcfGenotypeFormat.DS));
         genotypeDosageFieldPrecedence =
                 new LinkedHashSet<>(Arrays.asList(VcfGenotypeFormat.DS, VcfGenotypeFormat.GP, VcfGenotypeFormat.GT));
+        haplotypeProbabilitiesFieldPresedence =
+                new LinkedHashSet<>(Arrays.asList(VcfGenotypeFormat.HP, VcfGenotypeFormat.ADS));
 
         genotypeFormatSupplier = new VcfGenotypeFormatSupplier();
     }
@@ -321,15 +324,12 @@ public class VcfGenotypeData extends AbstractRandomAccessGenotypeData implements
         LinkedHashSet<VcfGenotypeFormat> haplotypeProbabilitiesFields = getVcfHaplotypeFormats(variant);
 
         // If the requested format is set and present for this variant base decision on this format
-        VcfGenotypeFormat genotypeFormat = genotypeFormatSupplier.getVcfGenotypeFormat(
+        return genotypeFormatSupplier.VcfGenotypeFormatReadable(
                 vcfRecord, haplotypeProbabilitiesFields);
-
-        return (genotypeFormat != null);
     }
 
     private LinkedHashSet<VcfGenotypeFormat> getVcfHaplotypeFormats(GeneticVariant variant) {
-        LinkedHashSet<VcfGenotypeFormat> haplotypeProbabilitiesFields =
-                new LinkedHashSet<>(Arrays.asList(VcfGenotypeFormat.HP, VcfGenotypeFormat.ADS));
+        LinkedHashSet<VcfGenotypeFormat> haplotypeProbabilitiesFields = haplotypeProbabilitiesFieldPresedence;
 
         if (variant.hasPhasedGenotypes()) {
             haplotypeProbabilitiesFields.add(VcfGenotypeFormat.GT);


### PR DESCRIPTION
Removed unnecessary print statement from bgen writer.
Improved handling of preferred genotype format fields for reading VCF files; now it's behaviour of choosing phased/unphased is more like expected (see wiki for details; will update the wiki soon)