### PR TITLE
Resolved bug in BGEN, BGI writer Genotype-IO, GH

### DIFF
--- a/Genotype-Harmonizer/pom.xml
+++ b/Genotype-Harmonizer/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>Genotype-Harmonizer</artifactId>
-	<version>1.4.26-SNAPSHOT</version>
+	<version>1.4.27-SNAPSHOT</version>
 	<name>Genotype Harmonizer</name>
 	<packaging>jar</packaging>
 	<dependencies>

--- a/Genotype-IO/src/main/java/org/molgenis/genotype/bgen/BgenGenotypeWriter.java
+++ b/Genotype-IO/src/main/java/org/molgenis/genotype/bgen/BgenGenotypeWriter.java
@@ -12,6 +12,8 @@ import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -303,10 +305,11 @@ public class BgenGenotypeWriter implements GenotypeWriter {
 
 		// Add current time in int.
 		// Create and write new metadata.
+		BasicFileAttributes basicFileAttributes = Files.readAttributes(bgenFile.toPath(), BasicFileAttributes.class);
 		BgenixMetadata m = new BgenixMetadata(
 				bgenFile.getName(),
-				(int) bgenFile.length(),
-				(int) (bgenFile.lastModified() / 1000L),
+				basicFileAttributes.size(),
+				basicFileAttributes.lastModifiedTime().toMillis() / 1000L,
 				firstBytes,
 				(System.currentTimeMillis() / 1000L));
 		bgenixWriter.writeMetadata(m);

--- a/Genotype-IO/src/main/java/org/molgenis/genotype/bgen/BgenixMetadata.java
+++ b/Genotype-IO/src/main/java/org/molgenis/genotype/bgen/BgenixMetadata.java
@@ -12,12 +12,12 @@ package org.molgenis.genotype.bgen;
 public class BgenixMetadata {
 	
 	private final String fileName;
-	private final int fileSize;
+	private final long fileSize;
 	private final long lastWriteTime;
 	private final byte[] first1000bytes;
 	private final long indexCreationTime;
 
-	public BgenixMetadata(String fileName, int fileSize, long lastWriteTime, byte[] first1000bytes, long indexCreationTime) {
+	public BgenixMetadata(String fileName, long fileSize, long lastWriteTime, byte[] first1000bytes, long indexCreationTime) {
 		this.fileName = fileName;
 		this.fileSize = fileSize;
 		this.lastWriteTime = lastWriteTime;
@@ -29,7 +29,7 @@ public class BgenixMetadata {
 		return fileName;
 	}
 
-	public int getFileSize() {
+	public long getFileSize() {
 		return fileSize;
 	}
 

--- a/Genotype-IO/src/main/java/org/molgenis/genotype/bgen/BgenixWriter.java
+++ b/Genotype-IO/src/main/java/org/molgenis/genotype/bgen/BgenixWriter.java
@@ -132,8 +132,11 @@ public class BgenixWriter {
 
 			PreparedStatement metadataStatement = dbConnection.prepareStatement("INSERT INTO Metadata(filename, file_size, last_write_time, first_1000_bytes, index_creation_time) VALUES(?,?,?,?,?)");
 
+			// The sqlite database requires integers for both file size and write time.
+			// However, in sqlite integers are up to 8 byte integers.
+			// This is equivalent to a long in java, therefore, we use setLong here.
 			metadataStatement.setString(1, metadata.getFileName());
-			metadataStatement.setInt(2, metadata.getFileSize());
+			metadataStatement.setLong(2, metadata.getFileSize());
 			metadataStatement.setLong(3, metadata.getLastWriteTime());
 			metadataStatement.setBytes(4, metadata.getFirst1000bytes());
 			metadataStatement.setLong(5, metadata.getIndexCreationTime());

--- a/Genotype-IO/src/test/java/org/molgenis/genotype/bgen/BgenixReaderNGTest.java
+++ b/Genotype-IO/src/test/java/org/molgenis/genotype/bgen/BgenixReaderNGTest.java
@@ -7,10 +7,8 @@ package org.molgenis.genotype.bgen;
 
 import java.io.File;
 import java.net.URISyntaxException;
-import java.sql.Connection;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
+
 import static org.testng.Assert.*;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;


### PR DESCRIPTION
Resolved bug in GH that caused in to write faulty file sizes for bgen files in the accompanying .bgi file.
Version bump for genotype harmonizer.